### PR TITLE
Fix GitHub Actions deploy: switch to official Pages actions

### DIFF
--- a/.github/workflows/update-feed.yaml
+++ b/.github/workflows/update-feed.yaml
@@ -11,22 +11,41 @@ on:
     # Recommended tool: https://crontab.guru/
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.1.4
+        uses: actions/setup-node@v4
         with:
           node-version: "16"
       - name: Install dependencies
         run: npm i
       - name: Build the feed
         run: npm run build
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./public
+          path: ./public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## 問題

2026-08-12以降、フィード更新用のGitHub Actionsワークフローがすべて `startup_failure`（ジョブが1つも起動しない）で失敗しており、サイトが更新されていませんでした。

実際のエラー:
```
The action peaceiris/actions-gh-pages@v3 is not allowed in ishikawa3/rss because all actions must
be from a repository owned by ishikawa3, created by GitHub, verified in the GitHub Marketplace, or
match the pattern: actions/checkout actions/setup-node peaceiris/actions-gh-pages.
```

リポジトリの Actions 許可アクションのポリシーにより、デプロイに使用していた `peaceiris/actions-gh-pages@v3` がブロックされていました。

## 変更内容

- `peaceiris/actions-gh-pages@v3` を GitHub公式の `actions/upload-pages-artifact@v3` + `actions/deploy-pages@v4` に置き換え、build/deployをジョブ分割
  - GitHub公式アクションは許可ポリシーに関わらず常に利用可能なため、今後同様の問題が起きません
- `actions/checkout@v2` → `v4`、`actions/setup-node@v2.1.4` → `v4` に更新（v2はGitHub-hostedランナーで非推奨）
- ワークフローに `permissions`（pages: write, id-token: write）と `concurrency` を追加（`actions/deploy-pages` の要件）

## 動作確認

このブランチで `workflow_dispatch` を手動実行し、buildジョブが正常に完了することを確認済みです（[run #1527](``https://github.com/ishikawa3/rss/actions/runs/32990129823)）。deployジョブは「mainブランチ以外からはgithub-pages環境にデプロイできない」という既定の環境保護ルールにより失敗しましたが、これは想定通りで、mainにマージされれば解消されます。``

なお、このPRのマージ前提として **Settings → Pages → Build and deployment → Source を「GitHub Actions」に変更済み**であることを確認しています。


---
_Generated by [Claude Code](https://claude.ai/code/session_01WJcEMpyUoAQfwC1YczfMSP)_