### PR TITLE
Fix broken feed URLs, and Copilot review follow-ups on PR #4

### DIFF
--- a/.github/workflows/update-feed.yaml
+++ b/.github/workflows/update-feed.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: "16"
+          node-version: "20"
       - name: Install dependencies
         run: npm i
       - name: Build the feed
@@ -41,6 +41,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 |---|---|
 | [Dezeen](https://www.dezeen.com/) | 建築・インテリア・プロダクトデザイン |
 | [Core77](https://www.core77.com/) | インダストリアルデザイン |
-| [Dexigner](https://www.dexigner.com/) | デザインニュース |
 | [Design Milk](https://design-milk.com/) | モダンデザイン |
 | [Creative Bloq](https://www.creativebloq.com/) | アート・デザイン全般 |
 | [AXIS](https://www.axismag.jp/) | デザイン・建築・ビジネス（日本語） |
@@ -22,22 +21,40 @@
 
 [awesome-japan-opendata](https://github.com/japan-opendata/awesome-japan-opendata) を参考にまとめたオープンデータ系フィードです。
 
+政府のオープンデータカタログは data.go.jp から
+[e-Gov データポータル](https://data.e-gov.go.jp/)（data.e-gov.go.jp）へ移転しました。
+省庁は `org_XXXX` 形式のコードで識別されます。コードと省庁名の対応は
+`https://data.e-gov.go.jp/data/api/action/organization_list?all_fields=true` で確認できます。
+
 | フィード | 説明 |
 |---|---|
-| [DATA GO JP](https://www.data.go.jp/) | 日本政府オープンデータカタログ（全省庁） |
-| [国土交通省](https://www.data.go.jp/) | data.go.jp 国土交通省新着 |
-| [内閣府](https://www.data.go.jp/) | data.go.jp 内閣府新着 |
-| [厚生労働省](https://www.data.go.jp/) | data.go.jp 厚生労働省新着 |
-| [文部科学省](https://www.data.go.jp/) | data.go.jp 文部科学省新着 |
-| [財務省](https://www.data.go.jp/) | data.go.jp 財務省新着 |
-| [農林水産省](https://www.data.go.jp/) | data.go.jp 農林水産省新着 |
-| [経済産業省](https://www.data.go.jp/) | data.go.jp 経済産業省新着 |
-| [環境省](https://www.data.go.jp/) | data.go.jp 環境省新着 |
-| [警察庁](https://www.data.go.jp/) | data.go.jp 警察庁新着 |
+| [e-Gov データポータル](https://data.e-gov.go.jp/) | 日本政府オープンデータカタログ（全省庁） |
+| 国土交通省 | e-Gov データポータル 国土交通省新着（`org_1900`） |
+| 内閣府 | e-Gov データポータル 内閣府新着（`org_0400`） |
+| 厚生労働省 | e-Gov データポータル 厚生労働省新着（`org_1600`） |
+| 文部科学省 | e-Gov データポータル 文部科学省新着（`org_1500`） |
+| 財務省 | e-Gov データポータル 財務省新着（`org_1400`） |
+| 農林水産省 | e-Gov データポータル 農林水産省新着（`org_1700`） |
+| 経済産業省 | e-Gov データポータル 経済産業省新着（`org_1800`） |
+| 環境省 | e-Gov データポータル 環境省新着（`org_2000`） |
+| 警察庁 | e-Gov データポータル 警察庁新着（`org_0700`） |
 | [デジタル庁](https://www.digital.go.jp/) | デジタル庁 新着情報 |
-| [e-Stat](https://www.e-stat.go.jp/) | 政府統計の総合窓口 |
-| [CODH](https://codh.rois.ac.jp/) | ROIS-DS 人文学オープンデータ共同利用センター |
 | [JIRCAS](https://www.jircas.go.jp/) | 国際農林水産業研究センター |
+
+> **省庁別フィードの表示件数について**  
+> osmosfeed は各記事の日付として Atom の `<published>`（＝データセットの初回公開日）を使います。
+> e-Gov データポータルのフィードには `<updated>`（メタデータ更新日）も含まれますが、
+> 更新されるのは大半が数年前に公開済みのデータセットのため、`cacheMaxDays: 30` の範囲には入りません。
+> 新規公開されるデータセットは全省庁合わせて月に数件程度で、省庁によっては数か月間ゼロになります。
+> 省庁別フィードが空欄でもフィード自体は正常です。件数を稼ぎたい場合は全省庁フィードのみでも内容は同じです。
+
+### 配信終了により削除したフィード
+
+| フィード | 理由 |
+|---|---|
+| Dexigner | サイト自体が2022年9月で更新停止。フィードも同時点から更新なし |
+| e-Stat | [RSSによる新着情報配信サービスが2023年9月30日で終了](https://www.e-stat.go.jp/rss) |
+| CODH | サイトがRSS/Atomフィードを提供していない |
 
 ## フィードの追加・変更方法
 

--- a/osmosfeed.yaml
+++ b/osmosfeed.yaml
@@ -1,22 +1,21 @@
 cacheUrl: https://ishikawa3.github.io/rss/cache.json
 sources:
   - href: https://www.dezeen.com/feed/ # Dezeen — architecture, interiors, design
-  - href: https://www.core77.com/rss # Core77 — industrial design
-  - href: https://feeds.feedburner.com/dexigner # Dexigner — design news
+  - href: https://www.core77.com/rss.xml # Core77 — industrial design
   - href: https://design-milk.com/feed/ # Design Milk — modern design
-  - href: https://www.creativebloq.com/feeds/all # Creative Bloq — art & design
+  - href: https://www.creativebloq.com/feeds.xml # Creative Bloq — art & design
   - href: https://www.axismag.jp/feed # AXIS — デザイン・建築・ビジネス
-  - href: https://www.data.go.jp/feed/dataset.rdf # DATA GO JP 全省庁 オープンデータ新着
-  - href: https://www.data.go.jp/feed/dataset/organization/mlit.rdf # 国土交通省 オープンデータ新着（data.go.jp）
-  - href: https://www.data.go.jp/feed/dataset/organization/cao.rdf # 内閣府 オープンデータ新着（data.go.jp）
-  - href: https://www.data.go.jp/feed/dataset/organization/mhlw.rdf # 厚生労働省 オープンデータ新着（data.go.jp）
-  - href: https://www.data.go.jp/feed/dataset/organization/mext.rdf # 文部科学省 オープンデータ新着（data.go.jp）
-  - href: https://www.data.go.jp/feed/dataset/organization/mof.rdf # 財務省 オープンデータ新着（data.go.jp）
-  - href: https://www.data.go.jp/feed/dataset/organization/maff.rdf # 農林水産省 オープンデータ新着（data.go.jp）
-  - href: https://www.data.go.jp/feed/dataset/organization/meti.rdf # 経済産業省 オープンデータ新着（data.go.jp）
-  - href: https://www.data.go.jp/feed/dataset/organization/env.rdf # 環境省 オープンデータ新着（data.go.jp）
-  - href: https://www.data.go.jp/feed/dataset/organization/npa.rdf # 警察庁 オープンデータ新着（data.go.jp）
-  - href: https://www.digital.go.jp/feed/ # デジタル庁 新着情報
-  - href: https://www.e-stat.go.jp/rss/feed # e-Stat 政府統計の総合窓口
-  - href: https://codh.rois.ac.jp/feed/ # ROIS-DS CODH 人文学オープンデータ共同利用センター
-  - href: https://www.jircas.go.jp/ja/rss/information # 国際農林水産業研究センター（JIRCAS）
+  # オープンデータは data.go.jp から e-Gov データポータル（data.e-gov.go.jp）へ移転済み。
+  # 省庁は org_XXXX 形式のコードで識別される（一覧は /data/api/action/organization_list?all_fields=true）。
+  - href: https://data.e-gov.go.jp/data/feeds/dataset.atom # e-Gov データポータル 全省庁 オープンデータ新着
+  - href: https://data.e-gov.go.jp/data/feeds/organization/org_1900.atom # 国土交通省 オープンデータ新着
+  - href: https://data.e-gov.go.jp/data/feeds/organization/org_0400.atom # 内閣府 オープンデータ新着
+  - href: https://data.e-gov.go.jp/data/feeds/organization/org_1600.atom # 厚生労働省 オープンデータ新着
+  - href: https://data.e-gov.go.jp/data/feeds/organization/org_1500.atom # 文部科学省 オープンデータ新着
+  - href: https://data.e-gov.go.jp/data/feeds/organization/org_1400.atom # 財務省 オープンデータ新着
+  - href: https://data.e-gov.go.jp/data/feeds/organization/org_1700.atom # 農林水産省 オープンデータ新着
+  - href: https://data.e-gov.go.jp/data/feeds/organization/org_1800.atom # 経済産業省 オープンデータ新着
+  - href: https://data.e-gov.go.jp/data/feeds/organization/org_2000.atom # 環境省 オープンデータ新着
+  - href: https://data.e-gov.go.jp/data/feeds/organization/org_0700.atom # 警察庁 オープンデータ新着
+  - href: https://www.digital.go.jp/rss/news.xml # デジタル庁 新着情報
+  - href: https://www.jircas.go.jp/ja/rss.xml # 国際農林水産業研究センター（JIRCAS）


### PR DESCRIPTION
## 1. フィードURLの修正（本命）

登録20フィードのうち、実際にサイトへ届いていたのは **3件だけ** でした。残り17件は毎回ダウンロードに失敗し、osmosfeedが黙ってスキップするため、ビルドは「成功」表示のままほとんど何も掲載されていない状態でした。

### URL修正（すべてリダイレクトなしで直接200を返すことを確認済み。osmosfeedは3xxを追わないため）

| フィード | 変更内容 |
|---|---|
| Core77 | `/rss` → `/rss.xml`（旧パスは404） |
| Creative Bloq | `/feeds/all` → `/feeds.xml`（旧パスは `http://` へ301） |
| デジタル庁 | `/feed/` → `/rss/news.xml`（旧パスは404） |
| JIRCAS | `/ja/rss/information` → `/ja/rss.xml`（旧パスは404） |
| オープンデータ10件 | data.go.jp が [e-Gov データポータル](https://data.e-gov.go.jp/) へ移転。CKANフィードは `/data/feeds/` 配下、省庁は名前スラッグから `org_XXXX` コードに変更されたため全て再マッピング |

### 削除（現存する代替フィードなし）

| フィード | 理由 |
|---|---|
| Dexigner | サイト自体が2022年9月で更新停止 |
| e-Stat | [RSS配信が2023年9月30日で終了](https://www.e-stat.go.jp/rss)（公式告知） |
| CODH | サイトがRSS/Atomを提供していない |

### 動作確認（CI実測）

[run #1532](https://github.com/ishikawa3/rss/actions/runs/33031107596) のログより、**スキップされたフィードはゼロ**：

```
cached   new     計  source
    51     0    51  dezeen.com/feed/
    14     0    14  design-milk.com/feed/
     0    15    15  core77.com/rss.xml          ← 復旧
    20     0    20  axismag.jp/feed
     0     2     2  data.e-gov.go.jp .../dataset.atom  ← 復旧
     0    29    29  digital.go.jp/rss/news.xml  ← 復旧
     0    25    25  creativebloq.com/feeds.xml  ← 復旧
     0     2     2  jircas.go.jp/ja/rss.xml     ← 復旧
    85    73   158  合計
```

修正前は3フィード85件、修正後は8フィード158件。

### 省庁別フィードが0件である件について

省庁別フィードのURLは正常に取得できていますが、表示件数は0件です。これは不具合ではなくデータ側の実態です：

- osmosfeed は記事日付として Atom の `<published>`（＝データセットの**初回公開日**）を使う
- e-Gov のフィードには `<updated>`（メタデータ更新日）も入っているが、更新されるのは大半が数年前に公開済みのデータセットで、`cacheMaxDays: 30` の範囲外
- 実際に新規公開されるデータセットは全省庁合計で**直近30日に3件**、90日で46件。省庁別では直近90日で国交省・内閣府・文科省・農水省・警察庁が**0件**

全省庁フィードが省庁別を包含するため、省庁別9件は整理してもサイトの掲載内容は変わりません。この点はREADMEに明記しました。

## 2. Copilotレビュー指摘への対応（PR #4のフォローアップ）

- `node-version` をEOLのNode 16からLTSのNode 20へ更新
- `deploy` ジョブに `if: github.ref == 'refs/heads/main'` を追加。これがないと `workflow_dispatch` を他ブランチで実行した際、保護された `github-pages` 環境へのデプロイ拒否で必ず失敗する

いずれも上記CI実行で検証済み（buildはNode 20で成功、deployは `skipped`）。
